### PR TITLE
Improvements for FlexIO SPI interfaces

### DIFF
--- a/src/FlexIO_t4.h
+++ b/src/FlexIO_t4.h
@@ -59,7 +59,6 @@ public:
 	// T4
 	static const uint8_t CNT_FLEX_PINS = 14;
 	static const uint8_t CNT_FLEX_IO_OBJECT = 3;
-	static const uint8_t CNT_TIMERS = 8
 #endif
 	typedef struct {
 		volatile uint32_t &clock_gate_register;


### PR DESCRIPTION
Fixed an issue with shifter loading/unloading for longer words and handling MSB/LSB correctly. Change to settings object to allow for specification of number of bits to transfer (up to 32) in each SPI transaction, which allows for hardware CS to be used for buffer and DMA transaction sequences that are different lengths than 8 bits.

I couldn't see a decent way to handle 3 byte strides in DMA transfers so I have everything in the 17-32 bit space in 4 bytes, so not as memory efficient as it could be, but figured it would be better to have consistent packing rules between buffer transfers and DMA transfers.

I've verified MOSI, CLK, and CS:  looks correct on loopback and on scope using a Teensy4.0, though as always probably could do with some more exhaustive testing.