### PR TITLE
Put #ifdef around all Serial.printf calls. Sometimes Serial does not exist

### DIFF
--- a/src/FlexIOSPI.cpp
+++ b/src/FlexIOSPI.cpp
@@ -18,7 +18,9 @@ bool FlexIOSPI::begin() {
 	//-------------------------------------------------------------------------
 	_pflex = FlexIOHandler::mapIOPinToFlexIOHandler(_mosiPin, _mosi_flex_pin);
 	if (!_pflex) {
+#ifdef DEBUG_FlexSPI
 		Serial.printf("FlexIOSPI - Mosi pin does not map to flex controller\n");
+#endif
 		return false;
 	}
 	//Serial.printf("FlexIOSPI Begin: Mosi map %d %x %d\n", _mosiPin, (uint32_t)_pflex, _mosi_flex_pin);
@@ -36,28 +38,36 @@ bool FlexIOSPI::begin() {
 			_pflex = FlexIOHandler::mapIOPinToFlexIOHandler(_miso_flex_pin, _miso_flex_pin); 			
  		}
  		if (!_pflex) {
-			Serial.printf("FlexIOSPI - not all pins mapped to same Flex controller\n");
-			return false;
- 		}
+#ifdef DEBUG_FlexSPI
+				Serial.printf("FlexIOSPI - not all pins mapped to same Flex controller\n");
+#endif
+				return false;
+		}
 
 		_mosi_flex_pin = _pflex->mapIOPinToFlexPin(_mosiPin);
 		_sck_flex_pin = _pflex->mapIOPinToFlexPin(_sckPin);
 		_miso_flex_pin = _pflex->mapIOPinToFlexPin(_misoPin);
  		if ((_sck_flex_pin == 0xff) || (_miso_flex_pin == 0xff) || (_mosi_flex_pin == 0xff)) {
+#ifdef DEBUG_FlexSPI
 			Serial.printf("FlexIOSPI - not all pins mapped to same Flex controller\n");
+#endif
 			return false;
  		}
  		#else
  			// 1052 don't have pins that map to different FLEXIO controllers
+#ifdef DEBUG_FlexSPI
 			Serial.printf("FlexIOSPI - not all pins mapped to same Flex controller\n");
+#endif
 			return false;
- 		#endif
+#endif
  	}
 	//FlexIOHandler *cs_flex = _pflex;
 	if (_csPin != -1) {
 		_cs_flex_pin = _pflex->mapIOPinToFlexPin(_csPin);
 		if (_cs_flex_pin == 0xff) {
+#ifdef DEBUG_FlexSPI
 			Serial.printf("FlexIOSPI - not all pins(CS) mapped to same Flex controller\n");
+#endif
 			return false;			
 		}
 	}
@@ -80,7 +90,9 @@ bool FlexIOSPI::begin() {
 		_pflex->freeShifter(_rx_shifter);
 		_tx_shifter = 0xff;
 		_rx_shifter = 0xff;
+#ifdef DEBUG_FlexSPI
 		Serial.println("FlexIOSPI - Failed to allocate timers or shifters");
+#endif
 		return false;
 	}
 

--- a/src/FlexIO_t4.cpp
+++ b/src/FlexIO_t4.cpp
@@ -232,9 +232,9 @@ uint8_t FlexIOHandler::mapIOPinToFlexPin(uint8_t pin)
   	// Now lets walk through all of the pins associated with this object. 
 	for (uint8_t i = 0; i < CNT_FLEX_PINS; i++ ) {
   		if (hardware().io_pin[i] == pin) {
-			#ifdef DEBUG_FlexIO
+#ifdef DEBUG_FlexIO
 			Serial.println("Enable flexio clock");
-			#endif
+#endif
 			hardware().clock_gate_register |= hardware().clock_gate_mask;
 
 			return hardware().flex_pin[i];
@@ -421,7 +421,9 @@ void FlexIOHandler::setClockSettings(uint8_t clk_sel, uint8_t clk_pred, uint8_t 
 		// PLL4 - We may need to enable this clock!
 		CCM_ANALOG_PLL_VIDEO_CLR = CCM_ANALOG_PLL_ARM_POWERDOWN | CCM_ANALOG_PLL_ARM_BYPASS;
 		CCM_ANALOG_PLL_VIDEO_SET = CCM_ANALOG_PLL_ARM_ENABLE;
+#ifdef DEBUG_FlexIO 
 		Serial.printf("CCM_ANALOG_PLL_VIDEO: %x\n", CCM_ANALOG_PLL_VIDEO);
+#endif
 	}
 	if ((IMXRT_FLEXIO_t *)port_addr == &IMXRT_FLEXIO1_S) {
 		// FlexIO1... 

--- a/src/FlexSerial.cpp
+++ b/src/FlexSerial.cpp
@@ -28,13 +28,17 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 		if (_tx_pflex != nullptr)  {
 			_tx_flex_pin = _tx_pflex->mapIOPinToFlexPin(_txPin);
 			if (_tx_flex_pin == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to map TX pin %d to FlexIO\n", _txPin);
 				return false;
+#endif
 			}
 		} else {
 			_tx_pflex = FlexIOHandler::mapIOPinToFlexIOHandler(_txPin, _tx_flex_pin);
 			if (_tx_pflex == nullptr) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to map TX pin %d to FlexIO\n", _txPin);
+#endif
 				return false;
 			}
 
@@ -50,25 +54,33 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 #endif		
 		if (_tx_timer <= 3) {
 			if (!_tx_pflex->claimTimer(_tx_timer)) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to claim TX timer(%d)\n", _tx_timer);
+#endif
 				return false;
 			}
 		} else {
 			_tx_timer = _tx_pflex->requestTimers();
 			if (_tx_timer == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to allocate TX timer(%d)\n", _tx_timer);
+#endif
 				return false;
 			}
 		}
 		if (_tx_shifter <= 3) {
 			if (!_tx_pflex->claimShifter(_tx_shifter)) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to claim TX shifter(%d)\n", _tx_shifter);
+#endif
 				return false;
 			}
 		} else {
 			_tx_shifter = _tx_pflex->requestShifter();
 			if (_tx_shifter == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to allocate TX shifter(%d)\n", _tx_shifter);
+#endif
 				return false;
 			}
 		}
@@ -126,13 +138,17 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 		if (_rx_pflex != nullptr)  {
 			_rx_flex_pin = _rx_pflex->mapIOPinToFlexPin(_rxPin);
 			if (_rx_flex_pin == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to map RX pin %d to FlexIO\n", _rxPin);
+#endif
 				return false;
 			}
 		} else {
 			_rx_pflex = FlexIOHandler::mapIOPinToFlexIOHandler(_rxPin, _rx_flex_pin);
 			if (_rx_pflex == nullptr) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to map RX pin %d to FlexIO\n", _rxPin);
+#endif
 				return false;
 			}
 
@@ -148,19 +164,25 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 #endif		
 		if (_rx_timer <= 3) {
 			if (!_rx_pflex->claimTimer(_rx_timer)) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to claim RX timer(%d)\n", _rx_timer);
+#endif
 				return false;
 			}
 		} else {
 			_rx_timer = _rx_pflex->requestTimers();
 			if (_rx_timer == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to allocate RX timer(%d)\n", _rx_timer);
+#endif
 				return false;
 			}
 		}
 		if (_rx_shifter <= 3) {
 			if (!_rx_pflex->claimShifter(_rx_shifter)) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to claim RX shifter(%d)\n", _rx_shifter);
+#endif
 				return false;
 			}
 		} else {
@@ -169,7 +191,9 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 
 			_rx_shifter = _rx_pflex->requestShifter(dma_channel_to_avoid);
 			if (_rx_shifter == 0xff) {
+#ifdef DEBUG_FlexSerial
 				Serial.printf("FlexSerial - Failed to allocate RX shifter(%d)\n", _rx_shifter);
+#endif
 				return false;
 			}
 		}
@@ -177,9 +201,9 @@ bool FlexSerial::begin(uint32_t baud, bool inverse_logic) {
 
 #ifdef DEBUG_FlexSerial
 		Serial.printf("timer index: %d shifter index: %d mask: %x\n", _rx_timer, _rx_shifter, _rx_shifter_mask);
-#endif
 		// lets try to configure a receiver like example
 		Serial.println("Before configure flexio");
+#endif
 		p->SHIFTCFG[_rx_shifter] = FLEXIO_SHIFTCFG_SSTOP(3) | FLEXIO_SHIFTCFG_SSTART(2); //0x0000_0032;
 		p->SHIFTCTL[_rx_shifter] = FLEXIO_SHIFTCTL_TIMPOL | FLEXIO_SHIFTCTL_SMOD(1) |
 		                              FLEXIO_SHIFTCTL_TIMSEL(_rx_timer) | FLEXIO_SHIFTCTL_PINSEL(_rx_flex_pin); // 0x0080_0001;
@@ -239,7 +263,9 @@ void FlexSerial::flush(void) {
 	uint32_t start_time = millis();
 	while (_transmitting) {
 		if ((millis()-start_time) > FLUSH_TIMEOUT) {
+#ifdef DEBUG_FlexSerial
 			Serial.println("*** FlexSerial::flush Timeout ***");
+#endif
 			return;
 		}
 		yield(); // wait


### PR DESCRIPTION
Hi Kurt, 
I am using your library in a context where Serial isn't defined because of my USB configuration. 
I am looking forward to your comments. 
Thanks, 
Patrick.